### PR TITLE
Fix directory tree in output build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ mkdir tmp
 
 # Compile jtwod Files
 echo "Compiling jtwod classes..."
-cp -R src/ tmp/
+cp -R src/* tmp/
 cd tmp/
 find . -name "*.java" > sources.txt
 javac -cp ../lib/tinysound-1.1.1.jar @sources.txt


### PR DESCRIPTION
Change directory to be jtwod/ instead of src/jtwod/ to be consistent with earlier builds.